### PR TITLE
Remove Tab Notif Test Values

### DIFF
--- a/eros/pages/index.tsx
+++ b/eros/pages/index.tsx
@@ -9,7 +9,7 @@ let notifEmojis = new Map<string, string>([
 ]);
 
 export default function Home() {
-	const notifs: string[] = ["message", "message", "gift", "message", "message", "friend"];
+	const notifs: string[] = [];
 
 	const title = notifs.length > 0 ? `Deveelo | ${notifEmojis.get(notifs[0]) + notifs.length}` : "Deveelo";
 


### PR DESCRIPTION
### 🤠 Purpose
This is a simple and quick pr to remove the testing values of the tab notification system from the [staging](https://github.com/Treixatek/deveelo/tree/staging) branch as it is prepared for [prod](https://github.com/Treixatek/deveelo/tree/prod).

### 📜 Code
This issue is on [line 12 of index.tsx](https://github.com/Treixatek/deveelo/blob/8ea2808f33247eff1d25520e20e4112f7e739dab/eros/pages/index.tsx#L12) in [eros](https://github.com/Treixatek/deveelo/tree/staging/eros). The array was not cleared of default values
````tsx
let notifEmojis = new Map<string, string>([
	["gift", "🎁"],
	["update", "🎀"],
	["message", "🔥"],
	["friend", "💝"],
	["views", "🔴"],
]);

const notifs: string[] = ["message", "message", "gift", "message", "message", "friend"];
````