### PR TITLE
Profile Display in Navbar & Use Real Status in Sidebar

### DIFF
--- a/eros/components/Layout.tsx
+++ b/eros/components/Layout.tsx
@@ -113,8 +113,6 @@ const Layout = ({ children, route, showSidebar, showActivityBar, showNav, useWid
 					{useWide && <SideImage route={route} hardEdge={full} />}
 					<div className={useWide ? (full ? styles.containerWide_full : styles.containerWide) : styles.container}>
 						<main className={styles.main}>
-							<p>{JSON.stringify(full)}</p>
-							<a href="/login">login</a>
 							<a href="/register">register</a>
 							{/* <h2>Full</h2>
 							<p>Logged in user: {error && !loading ? error : text}</p> */}

--- a/eros/components/Nav.tsx
+++ b/eros/components/Nav.tsx
@@ -14,8 +14,10 @@ const Nav = ({ sidebarSpacing }: { sidebarSpacing: boolean }) => {
 	if (getAccessToken() === "") {
 		// handle logged out users
 		profile = (
-			<div className={navStyles.buttonWrapper}>
-				<TextButton colorKey="gold" text="Login" action="/login" />
+			<div className={navStyles.rightWrapper}>
+				<div className={navStyles.buttonWrapper}>
+					<TextButton colorKey="gold" text="Login" action="/login" />
+				</div>
 			</div>
 		);
 	} else {
@@ -29,11 +31,14 @@ const Nav = ({ sidebarSpacing }: { sidebarSpacing: boolean }) => {
 		const user = data.myAccount;
 
 		profile = (
-			<>
+			<div className={navStyles.rightWrapper}>
 				<div className={navStyles.profile}>
-					<ProfilePicture size="w40" source={user.profile.pictureUrl} />
+					<p className={navStyles.name}>{user.account.username}</p>
+					<div className={navStyles.pfpContainer}>
+						<ProfilePicture size="w40" source={user.profile.pictureUrl} />
+					</div>
 				</div>
-			</>
+			</div>
 		);
 	}
 
@@ -48,7 +53,7 @@ const Nav = ({ sidebarSpacing }: { sidebarSpacing: boolean }) => {
 					</li>
 				</ul>
 			</div>
-			<div className={navStyles.rightWrapper}>{profile}</div>
+			{profile}
 		</nav>
 	);
 };

--- a/eros/components/Nav.tsx
+++ b/eros/components/Nav.tsx
@@ -15,7 +15,7 @@ const Nav = ({ sidebarSpacing }: { sidebarSpacing: boolean }) => {
 		// handle logged out users
 		profile = (
 			<div className={navStyles.buttonWrapper}>
-				<TextButton colorKey="gold" text="Login" />
+				<TextButton colorKey="gold" text="Login" action="/login" />
 			</div>
 		);
 	} else {

--- a/eros/components/Nav.tsx
+++ b/eros/components/Nav.tsx
@@ -1,11 +1,45 @@
 import navStyles from "../styles/nav.module.css";
 import Link from "next/link";
+
 import TitleMenu from "./minor/TitleMenu";
+import ProfilePicture from "./micro/ProfilePicture";
+import TextButton from "./micro/TextButton";
 import isLuna from "../hooks/isLuna";
+import { useMyNameAndPfpQuery } from "../hooks/backend/generated/graphql";
+import { getAccessToken } from "../accessToken";
 
 const Nav = ({ sidebarSpacing }: { sidebarSpacing: boolean }) => {
+	let profile = null;
+
+	if (getAccessToken() === "") {
+		// handle logged out users
+		profile = (
+			<div className={navStyles.buttonWrapper}>
+				<TextButton colorKey="gold" text="Login" />
+			</div>
+		);
+	} else {
+		//user is logged in
+		const { data, loading, error } = useMyNameAndPfpQuery();
+
+		if (loading && !data) {
+			return <div></div>;
+		}
+
+		const user = data.myAccount;
+
+		profile = (
+			<>
+				<div className={navStyles.profile}>
+					<ProfilePicture size="w40" source={user.profile.pictureUrl} />
+				</div>
+			</>
+		);
+	}
+
 	return (
 		<nav className={sidebarSpacing ? (isLuna() ? navStyles.nav : navStyles.nav_full) : isLuna() ? navStyles.navNoSpace : navStyles.navNoSpace_full}>
+			{/* the name & app version */}
 			<div className={navStyles.wrapper}>
 				{isLuna() ? <TitleMenu /> : null}
 				<ul>
@@ -14,6 +48,7 @@ const Nav = ({ sidebarSpacing }: { sidebarSpacing: boolean }) => {
 					</li>
 				</ul>
 			</div>
+			<div className={navStyles.rightWrapper}>{profile}</div>
 		</nav>
 	);
 };

--- a/eros/components/Sidebar.tsx
+++ b/eros/components/Sidebar.tsx
@@ -117,7 +117,7 @@ const Sidebar = ({ hardEdge }: sidebarProps) => {
 							<p className={sidebarStyles.p_stats_num}>{user.profile.followingIds.length}</p>
 							<p className={sidebarStyles.p_stats_label}>Following</p>
 						</div>
-						<ProfilePicture size="large" source={user.profile.pictureUrl} />
+						<ProfilePicture size="large" source={user.profile.pictureUrl} status={user.status} />
 						<div className={sidebarStyles.p_stats}>
 							<p className={sidebarStyles.p_stats_num}>{user.profile.followerIds.length}</p>
 							<p className={sidebarStyles.p_stats_label}>Followers</p>

--- a/eros/components/Sidebar.tsx
+++ b/eros/components/Sidebar.tsx
@@ -102,8 +102,6 @@ const Sidebar = ({ hardEdge }: sidebarProps) => {
 		);
 	}
 
-	const link = process.env.NODE_ENV === "production" ? `https://www.deveelo.com${user.profile.pictureUrl}` : `http://localhost:3000${user.profile.pictureUrl}`;
-
 	return (
 		<div className={hardEdge ? sidebarStyles.sidebar_full : sidebarStyles.sidebar}>
 			{/*Banner*/}
@@ -119,7 +117,7 @@ const Sidebar = ({ hardEdge }: sidebarProps) => {
 							<p className={sidebarStyles.p_stats_num}>{user.profile.followingIds.length}</p>
 							<p className={sidebarStyles.p_stats_label}>Following</p>
 						</div>
-						<ProfilePicture size="large" source={link} />
+						<ProfilePicture size="large" source={user.profile.pictureUrl} />
 						<div className={sidebarStyles.p_stats}>
 							<p className={sidebarStyles.p_stats_num}>{user.profile.followerIds.length}</p>
 							<p className={sidebarStyles.p_stats_label}>Followers</p>

--- a/eros/components/micro/ProfilePicture.tsx
+++ b/eros/components/micro/ProfilePicture.tsx
@@ -5,17 +5,33 @@ import Image from "next/image";
 interface profilePicParams {
 	size: string;
 	source: string;
+	status?: string;
 }
 
-const ProfilePicture = ({ size, source }: profilePicParams) => {
+const ProfilePicture = ({ size, source, status }: profilePicParams) => {
 	let content = null;
+	let circle = null;
+
+	switch (status) {
+		case "online":
+			circle = <div className={statusStyles.online} />;
+			break;
+		case "idle":
+			circle = <div className={statusStyles.idle} />;
+			break;
+		case "dnd":
+			circle = <div className={statusStyles.dnd} />;
+			break;
+		default:
+			break;
+	}
 
 	switch (size) {
 		case "large":
 			content = (
 				<>
 					<Image className={pictureStyles.p_picture} alt="profile picture" src={source} layout="fill" objectFit="cover" />
-					<div className={statusStyles.indicatorLarge} />
+					{status ? <div className={statusStyles.large}>{circle}</div> : null}
 				</>
 			);
 			break;

--- a/eros/components/micro/ProfilePicture.tsx
+++ b/eros/components/micro/ProfilePicture.tsx
@@ -32,15 +32,55 @@ const ProfilePicture = ({ size, source, status }: profilePicParams) => {
 	switch (size) {
 		case "large":
 			content = (
-				<>
+				<div className={pictureStyles.w70}>
 					<Image className={pictureStyles.p_picture} alt="profile picture" src={source} layout="fill" objectFit="cover" />
 					{status ? <div className={statusStyles.large}>{circle}</div> : null}
-				</>
+				</div>
+			);
+			break;
+		case "w50":
+			content = (
+				<div className={pictureStyles.w50}>
+					<Image className={pictureStyles.p_picture} alt="profile picture" src={source} layout="fill" objectFit="cover" />
+					{status ? <div className={statusStyles.large}>{circle}</div> : null}
+				</div>
+			);
+			break;
+		case "w40":
+			content = (
+				<div className={pictureStyles.w40}>
+					<Image className={pictureStyles.p_picture} alt="profile picture" src={source} layout="fill" objectFit="cover" />
+					{status ? <div className={statusStyles.large}>{circle}</div> : null}
+				</div>
+			);
+			break;
+		case "w36":
+			content = (
+				<div className={pictureStyles.w36}>
+					<Image className={pictureStyles.p_picture} alt="profile picture" src={source} layout="fill" objectFit="cover" />
+					{status ? <div className={statusStyles.large}>{circle}</div> : null}
+				</div>
+			);
+			break;
+		case "w32":
+			content = (
+				<div className={pictureStyles.w32}>
+					<Image className={pictureStyles.p_picture} alt="profile picture" src={source} layout="fill" objectFit="cover" />
+					{status ? <div className={statusStyles.large}>{circle}</div> : null}
+				</div>
+			);
+			break;
+		case "w28":
+			content = (
+				<div className={pictureStyles.w28}>
+					<Image className={pictureStyles.p_picture} alt="profile picture" src={source} layout="fill" objectFit="cover" />
+					{status ? <div className={statusStyles.large}>{circle}</div> : null}
+				</div>
 			);
 			break;
 	}
 
-	return <div className={pictureStyles.p_pictureWrapper}>{content}</div>;
+	return content;
 };
 
 export default ProfilePicture;

--- a/eros/components/micro/ProfilePicture.tsx
+++ b/eros/components/micro/ProfilePicture.tsx
@@ -22,6 +22,9 @@ const ProfilePicture = ({ size, source, status }: profilePicParams) => {
 		case "dnd":
 			circle = <div className={statusStyles.dnd} />;
 			break;
+		case "offline":
+			circle = <div className={statusStyles.offline} />;
+			break;
 		default:
 			break;
 	}

--- a/eros/components/micro/TextButton.tsx
+++ b/eros/components/micro/TextButton.tsx
@@ -29,14 +29,14 @@ const TextButton = ({ colorKey, text, submit, action, disabled }: buttonParams) 
 			break;
 		case "green":
 			content = (
-				<button className={buttonStyles.greenGrad} type={submit ? "submit" : undefined}>
+				<button className={buttonStyles.greenGrad} type={submit ? "submit" : undefined} onClick={(e) => handlePress()}>
 					{text}
 				</button>
 			);
 			break;
 		default:
 			content = (
-				<button className={buttonStyles.goldGrad} type={submit ? "submit" : undefined}>
+				<button className={buttonStyles.goldGrad} type={submit ? "submit" : undefined} onClick={(e) => handlePress()}>
 					{text}
 				</button>
 			);

--- a/eros/components/micro/TextButton.tsx
+++ b/eros/components/micro/TextButton.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from "next/router";
 import buttonStyles from "../../styles/textbutton.module.css";
 
 interface buttonParams {
@@ -9,12 +10,19 @@ interface buttonParams {
 }
 
 const TextButton = ({ colorKey, text, submit, action, disabled }: buttonParams) => {
+	const router = useRouter();
 	let content: any = null;
+
+	const handlePress = () => {
+		if (action && !submit) {
+			router.push(action);
+		}
+	};
 
 	switch (colorKey) {
 		case "gold":
 			content = (
-				<button className={buttonStyles.goldGrad} type={submit ? "submit" : undefined}>
+				<button className={buttonStyles.goldGrad} type={submit ? "submit" : undefined} onClick={(e) => handlePress()}>
 					{text}
 				</button>
 			);

--- a/eros/hooks/backend/generated/graphql.tsx
+++ b/eros/hooks/backend/generated/graphql.tsx
@@ -140,6 +140,11 @@ export type MyAccountMinProfileQueryVariables = Exact<{ [key: string]: never; }>
 
 export type MyAccountMinProfileQuery = { __typename?: 'Query', myAccount: { __typename?: 'User', status: string, account: { __typename?: 'U_Account', username: string, tag: string, private: boolean }, profile: { __typename?: 'U_Profile', bannerUrl: string, pictureUrl: string, description: string, followingIds: Array<Maybe<string>>, followerIds: Array<Maybe<string>>, badges: Array<Maybe<string>>, linkedProfiles: Array<Maybe<string>> } } };
 
+export type MyNameAndPfpQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type MyNameAndPfpQuery = { __typename?: 'Query', myAccount: { __typename?: 'User', account: { __typename?: 'U_Account', username: string }, profile: { __typename?: 'U_Profile', pictureUrl: string } } };
+
 export type RandomMinProfileQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -323,6 +328,45 @@ export function useMyAccountMinProfileLazyQuery(baseOptions?: Apollo.LazyQueryHo
 export type MyAccountMinProfileQueryHookResult = ReturnType<typeof useMyAccountMinProfileQuery>;
 export type MyAccountMinProfileLazyQueryHookResult = ReturnType<typeof useMyAccountMinProfileLazyQuery>;
 export type MyAccountMinProfileQueryResult = Apollo.QueryResult<MyAccountMinProfileQuery, MyAccountMinProfileQueryVariables>;
+export const MyNameAndPfpDocument = gql`
+    query myNameAndPfp {
+  myAccount {
+    account {
+      username
+    }
+    profile {
+      pictureUrl
+    }
+  }
+}
+    `;
+
+/**
+ * __useMyNameAndPfpQuery__
+ *
+ * To run a query within a React component, call `useMyNameAndPfpQuery` and pass it any options that fit your needs.
+ * When your component renders, `useMyNameAndPfpQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useMyNameAndPfpQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useMyNameAndPfpQuery(baseOptions?: Apollo.QueryHookOptions<MyNameAndPfpQuery, MyNameAndPfpQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<MyNameAndPfpQuery, MyNameAndPfpQueryVariables>(MyNameAndPfpDocument, options);
+      }
+export function useMyNameAndPfpLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<MyNameAndPfpQuery, MyNameAndPfpQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<MyNameAndPfpQuery, MyNameAndPfpQueryVariables>(MyNameAndPfpDocument, options);
+        }
+export type MyNameAndPfpQueryHookResult = ReturnType<typeof useMyNameAndPfpQuery>;
+export type MyNameAndPfpLazyQueryHookResult = ReturnType<typeof useMyNameAndPfpLazyQuery>;
+export type MyNameAndPfpQueryResult = Apollo.QueryResult<MyNameAndPfpQuery, MyNameAndPfpQueryVariables>;
 export const RandomMinProfileDocument = gql`
     query randomMinProfile {
   randomUser {

--- a/eros/hooks/backend/graphql/myNameAndPfp.gql
+++ b/eros/hooks/backend/graphql/myNameAndPfp.gql
@@ -1,0 +1,10 @@
+query myNameAndPfp {
+	myAccount {
+		account {
+			username
+		}
+		profile {
+			pictureUrl
+		}
+	}
+}

--- a/eros/styles/globals.css
+++ b/eros/styles/globals.css
@@ -1,6 +1,7 @@
 :root {
   /*backgrounds & text*/
   --textBlack: #121B2B;
+  --textBlueish: #1E325A; /*username in nav bar*/
   --textNormalCol: #49566F; /*profile description*/
   --midFadeGray: #7688AB; /*profile tag*/
   --midLightGray: #99AAC3;

--- a/eros/styles/globals.css
+++ b/eros/styles/globals.css
@@ -12,6 +12,7 @@
   --idle: #FFB129;
   --midpoint: #FF9059;
   --dnd: #FF6F89;
+  --offline: #BBC8DB;
 }
 
 /* ELEMENT STYLING */

--- a/eros/styles/nav.module.css
+++ b/eros/styles/nav.module.css
@@ -1,3 +1,4 @@
+/* NAVBAR */
 .nav {
   position: absolute;
   padding-left: 30.9375em;
@@ -86,6 +87,7 @@
   width: fit-content;
 }
 
+/* LEFT: NAME TEXT AREA */
 
 .boldTitle {
   font-weight: 700;
@@ -106,9 +108,44 @@
   flex-direction: column;
   
   height: 60%;
-  width: 20rem;
+  width: fit-content;
   margin-left: 3rem;
 }
+
+/* RIGHT: MAIN CONTENT */
+
+.rightWrapper {
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  flex-direction: column;
+  width: 100%;
+  height: inherit;
+
+  margin-left: 1.875rem;
+  padding-right: 2.141rem;
+
+  border: 2px solid rgb(0, 140, 255);
+  border-radius: 8px;
+}
+
+.profile {
+  display: flex;
+  align-items: flex-end;
+  flex-direction: column;
+
+  width: 16.984rem;
+  height: 3.75rem;
+}
+
+.buttonWrapper {
+  display: flex;
+
+  width: 11rem;
+  height: 3rem;
+}
+
+/* MENUBAR - LUNA ONLY */
 
 .menubar {
   position: relative;

--- a/eros/styles/nav.module.css
+++ b/eros/styles/nav.module.css
@@ -125,17 +125,44 @@
   margin-left: 1.875rem;
   padding-right: 2.141rem;
 
-  border: 2px solid rgb(0, 140, 255);
+  /* border: 2px solid rgb(0, 140, 255); */
   border-radius: 8px;
 }
 
 .profile {
   display: flex;
-  align-items: flex-end;
-  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  flex-direction: row;
+
+  /* background-color: khaki; */
 
   width: 16.984rem;
   height: 3.75rem;
+}
+
+.name {
+  overflow: hidden;
+  width: 12.187rem;
+  height: 2.344rem;
+
+  font-family: Heebo;
+  font-style: normal;
+  font-weight: 500;
+  font-size: 1.312rem;
+  line-height: 1.968rem;
+  display: flex;
+  align-items: center;
+  justify-content: end;
+  text-align: right;
+
+  color: var(--textBlueish);
+  margin: 0 1.087rem 0 0;
+}
+
+.pfpContainer {
+  width: fit-content;
+  height: inherit;
 }
 
 .buttonWrapper {

--- a/eros/styles/profilepicture.module.css
+++ b/eros/styles/profilepicture.module.css
@@ -1,8 +1,9 @@
-.p_pictureWrapper {
+/* Sidebar pfps, for user's and groups */
+.w70 {
     position: relative;
     width: 6.5625em;
     height: 6.5625em;
-    border-radius: 9.09375em;
+    border-radius: 50%;
     box-shadow: 0 0 0 0.8em var(--sidebarBackground);
 
     flex: none;
@@ -12,11 +13,50 @@
     margin-right: 1.4062em;
 }
 
+/* pfps in create post & on blog cards */
+.w50 {
+    position: relative;
+    width: 4.688em;
+    height: 4.688em;
+    border-radius: 50%;
+}
+
+/* navbar pfp & sidebar following list pfps */
+.w40 {
+    position: relative;
+    width: 3.75em;
+    height: 3.75em;
+    border-radius: 50%;
+}
+
+/* Used as pfp on posts in main feed */
+.w36 {
+    position: relative;
+    width: 3.395em;
+    height: 3.395em;
+    border-radius: 50%;
+}
+
+/* Everywhere, profiles, activity bar, stories... */
+.w32 {
+    position: relative;
+    width: 3em;
+    height: 3em;
+    border-radius: 50%;
+}
+
+/* pfp next to chat bubble */
+.w28 {
+    position: relative;
+    width: 2.625em;
+    height: 2.625em;
+    border-radius: 50%;
+}
+
 .p_picture {
-    
     overflow: hidden;
     
-    border-radius: 9.09375em;
+    border-radius: 50%;
     background-color: #EEF0F4;
     image-rendering: -webkit-optimize-contrast; /*stops blur*/
 }

--- a/eros/styles/status.module.css
+++ b/eros/styles/status.module.css
@@ -1,6 +1,7 @@
 /*Profiles*/
-.indicatorLarge {
+.large {
     position: relative;
+    overflow: hidden;
     left: 4.6875em;
     top: 4.4062em;
 
@@ -8,8 +9,29 @@
 
     width: 1.875em;
     height: 1.875em;
-    border-radius: 100em;
-    border: 0.2812em solid var(--sidebarBackground);
-  
+    border-radius: 50%;
+}
+
+.online {
+    width: inherit;
+    height: inherit;
     background-color: var(--online);
+    border: 0.2812em solid var(--sidebarBackground);
+    border-radius: inherit;
+}
+
+.idle {
+    width: inherit;
+    height: inherit;
+    background-color: var(--idle);
+    border: 0.2812em solid var(--sidebarBackground);
+    border-radius: inherit;
+}
+
+.dnd {
+    width: inherit;
+    height: inherit;
+    background-color: var(--dnd);
+    border: 0.2812em solid var(--sidebarBackground);
+    border-radius: inherit;
 }

--- a/eros/styles/status.module.css
+++ b/eros/styles/status.module.css
@@ -35,3 +35,11 @@
     border: 0.2812em solid var(--sidebarBackground);
     border-radius: inherit;
 }
+
+.offline {
+    width: inherit;
+    height: inherit;
+    background-color: var(--offline);
+    border: 0.2812em solid var(--sidebarBackground);
+    border-radius: inherit;
+}


### PR DESCRIPTION
### 📜 Purpose
This pr began work on the navbar in [eros](https://github.com/Treixatek/deveelo/tree/staging/eros). In an effort towards the completed mvp of the navbar, this pr implements the right hand side, containing the user's username and profile picture which will eventually be used to spawn a dropdown menu. In the process of loading a profile picture to the navbar, a modular and reusable system was built, and status indicators now use the real status, fetched from the database.

### 🎯 Additions
- [x] Real activity status on profiles
- [x] Login button for logged out users
- [x] Name & profile display